### PR TITLE
Deprecate mixed case parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,34 +13,34 @@
 #
 # === Parameters
 #
-# [*noAutoUpdate*]
+# [*no_auto_update*]
 # Ensuring the state of automatic updates.
 # 0: Automatic Updates is enabled (default)
 # 1: Automatic Updates is disabled.
 #
-# [*aUOptions*]
+# [*au_options*]
 # The option to configure what to do when an update is avaliable
 # 1: Keep my computer up to date has been disabled in Automatic Updates.
 # 2: Notify of download and installation.
 # 3: Automatically download and notify of installation.
 # 4: Automatically download and scheduled installation.
 #
-# [*scheduledInstallDay*]
+# [*scheduled_install_day*]
 # The day of the week to install updates.
 # 0: Every day.
 # 1 through 7: The days of the week from Sunday (1) to Saturday (7).
 #
-# [*scheduledInstallTime*]
+# [*scheduled_install_time*]
 # The time of day (in 24hr format) when to install updates.
 #
-# [*useWUServer*]
+# [*use_wuserver*]
 # If set to 1, windows autoupdates will use a local WSUS server rather than windows update.
 #
-# [*rescheduleWaitTime*]
+# [*reschedule_wait_time*]
 # The time period to wait between the time Automatic Updates starts and the time it begins installations
 # where the scheduled times have passed. The time is set in minutes from 1 to 60
 #
-# [*noAutoRebootWithLoggedOnUsers*]
+# [*no_auto_reboot_with_logged_on_users*]
 # If set to 1, Automatic Updates does not automatically restart a computer while users are logged on.
 #
 # === Examples
@@ -51,7 +51,7 @@
 #
 # Disable auto updates (don't do this!):
 #
-#   class { 'windows_autoupdate': noAutoUpdate => '1' }
+#   class { 'windows_autoupdate': no_auto_update => '1' }
 #
 class windows_autoupdate(
   $noAutoUpdate                  = $windows_autoupdate::params::noAutoUpdate,
@@ -60,16 +60,73 @@ class windows_autoupdate(
   $scheduledInstallTime          = $windows_autoupdate::params::scheduledInstallTime,
   $useWUServer                   = $windows_autoupdate::params::useWUServer,
   $rescheduleWaitTime            = $windows_autoupdate::params::rescheduleWaitTime,
-  $noAutoRebootWithLoggedOnUsers = $windows_autoupdate::params::noAutoRebootWithLoggedOnUsers
+  $noAutoRebootWithLoggedOnUsers = $windows_autoupdate::params::noAutoRebootWithLoggedOnUsers,
+
+  $au_options                          = $windows_autoupdate::params::au_options,
+  $no_auto_reboot_with_logged_on_users = $windows_autoupdate::params::no_auto_reboot_with_logged_on_users,
+  $no_auto_update                      = $windows_autoupdate::params::no_auto_update,
+  $reschedule_wait_time                = $windows_autoupdate::params::reschedule_wait_time,
+  $scheduled_install_day               = $windows_autoupdate::params::scheduled_install_day,
+  $scheduled_install_time              = $windows_autoupdate::params::scheduled_install_time,
+  $use_wuserver                        = $windows_autoupdate::params::use_wuserver,
 ) inherits windows_autoupdate::params {
 
-  validate_re($noAutoUpdate,['^[0,1]$'])
-  validate_re($aUOptions,['^[1-4]$'])
-  validate_re($scheduledInstallDay,['^[0-7]$'])
-  validate_re($scheduledInstallTime,['^(2[0-3]|1?[0-9])$'])
-  validate_re($useWUServer,['^[0,1]$'])
-  validate_re($rescheduleWaitTime,['^(60|[1-5][0-9]|[1-9])$'])
-  validate_re($noAutoRebootWithLoggedOnUsers,['^[0,1]$'])
+  if $aUOptions {
+    warning("${module_name}: The use of aUOptions is deprecated. Use au_options instead.")
+    $real_au_options = $aUOptions
+  } else {
+    $real_au_options = $au_options
+  }
+
+  if $noAutoRebootWithLoggedOnUsers {
+    warning("${module_name}: The use of noAutoRebootWithLoggedOnUsers is deprecated. Use no_auto_reboot_with_logged_on_users instead.")
+    $real_no_auto_reboot_with_logged_on_users = $noAutoRebootWithLoggedOnUsers
+  } else {
+    $real_no_auto_reboot_with_logged_on_users = $no_auto_reboot_with_logged_on_users
+  }
+
+  if $noAutoUpdate {
+    warning("${module_name}: The use of noAutoUpdate is deprecated. Use no_auto_update instead.")
+    $real_no_auto_update = $noAutoUpdate
+  } else {
+    $real_no_auto_update = $no_auto_update
+  }
+
+  if $rescheduleWaitTime {
+    warning("${module_name}: The use of rescheduleWaitTime is deprecated. Use reschedule_wait_time instead.")
+    $real_reschedule_wait_time = $rescheduleWaitTime
+  } else {
+    $real_reschedule_wait_time = $reschedule_wait_time
+  }
+
+  if $scheduledInstallDay {
+    warning("${module_name}: The use of scheduledInstallDay is deprecated. Use scheduled_install_day instead.")
+    $real_scheduled_install_day = $scheduledInstallDay
+  } else {
+    $real_scheduled_install_day = $scheduled_install_day
+  }
+
+  if $scheduledInstallTime {
+    warning("${module_name}: The use of cheduledInstallTime is deprecated. Use scheduled_install_time instead.")
+    $real_scheduled_install_time = $scheduledInstallTime
+  } else {
+    $real_scheduled_install_time = $scheduled_install_time
+  }
+
+  if $useWUServer {
+    warning("${module_name}: The use of useWUServer is deprecated. Use use_wuserver instead.")
+    $real_use_wuserver = $useWUServer
+  } else {
+    $real_use_wuserver = $use_wuserver
+  }
+
+  validate_re($real_no_auto_update,['^[0,1]$'])
+  validate_re($real_au_options,['^[1-4]$'])
+  validate_re($real_scheduled_install_day,['^[0-7]$'])
+  validate_re($real_scheduled_install_time,['^(2[0-3]|1?[0-9])$'])
+  validate_re($real_use_wuserver,['^[0,1]$'])
+  validate_re($real_reschedule_wait_time,['^(60|[1-5][0-9]|[1-9])$'])
+  validate_re($real_no_auto_reboot_with_logged_on_users,['^[0,1]$'])
 
   service { 'wuauserv':
     ensure    => 'running',
@@ -85,48 +142,48 @@ class windows_autoupdate(
     ensure => present,
     path   => "${windows_autoupdate::params::p_reg_key}\\NoAutoUpdate",
     type   => 'dword',
-    data   => $noAutoUpdate
+    data   => $real_no_auto_update
   }
 
   registry_value { 'AUOptions':
     ensure => present,
     path   => "${windows_autoupdate::params::p_reg_key}\\AUOptions",
     type   => 'dword',
-    data   => $aUOptions
+    data   => $real_au_options
   }
 
   registry_value { 'ScheduledInstallDay':
     ensure => present,
     path   => "${windows_autoupdate::params::p_reg_key}\\ScheduledInstallDay",
     type   => 'dword',
-    data   => $scheduledInstallDay
+    data   => $real_scheduled_install_day
   }
 
   registry_value { 'ScheduledInstallTime':
     ensure => present,
     path   => "${windows_autoupdate::params::p_reg_key}\\ScheduledInstallTime",
     type   => 'dword',
-    data   => $scheduledInstallTime
+    data   => $real_scheduled_install_time
   }
 
   registry_value { 'UseWUServer':
     ensure => present,
     path   => "${windows_autoupdate::params::p_reg_key}\\UseWUServer",
     type   => 'dword',
-    data   => $useWUServer
+    data   => $real_use_wuserver
   }
 
   registry_value { 'RescheduleWaitTime':
     ensure => present,
     path   => "${windows_autoupdate::params::p_reg_key}\\RescheduleWaitTime",
     type   => 'dword',
-    data   => $rescheduleWaitTime
+    data   => $real_reschedule_wait_time
   }
 
   registry_value { 'NoAutoRebootWithLoggedOnUsers':
     ensure => present,
     path   => "${windows_autoupdate::params::p_reg_key}\\NoAutoRebootWithLoggedOnUsers",
     type   => 'dword',
-    data   => $noAutoRebootWithLoggedOnUsers
+    data   => $real_no_auto_reboot_with_logged_on_users
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,13 +9,21 @@
 #
 class windows_autoupdate::params {
 
-  $noAutoUpdate = '0'
-  $aUOptions = '4'
-  $scheduledInstallDay = '1'
-  $scheduledInstallTime = '10'
-  $useWUServer = '0'
-  $rescheduleWaitTime = '10'
-  $noAutoRebootWithLoggedOnUsers = '0'
+  $noAutoUpdate = undef
+  $aUOptions = undef
+  $scheduledInstallDay = undef
+  $scheduledInstallTime = undef
+  $useWUServer = undef
+  $rescheduleWaitTime = undef
+  $noAutoRebootWithLoggedOnUsers = undef
+
+  $au_options                          = '4'
+  $no_auto_reboot_with_logged_on_users = '0'
+  $no_auto_update                      = '0'
+  $reschedule_wait_time                = '10'
+  $scheduled_install_day               = '1'
+  $scheduled_install_time              = '10'
+  $use_wuserver                        = '0'
 
   if $::operatingsystemrelease == 'Server 2012' {
     $p_reg_key = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update'

--- a/spec/classes/windows_autoupdate_spec.rb
+++ b/spec/classes/windows_autoupdate_spec.rb
@@ -1,18 +1,14 @@
 require 'spec_helper'
 
-class String
-  def titlecase
-    tr('_', ' ').
-    gsub(/\s+/, ' ').
-    gsub(/\b\w/){ $`[-1,1] == "'" ? $& : $&.upcase }
-  end
-end
-
 $p_reg_key = 'HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU'
 
-$defaults = { 'noAutoUpdate' => '0', 'aUOptions' => '4', 'scheduledInstallDay' => '1',
-              'scheduledInstallTime' => '1', 'useWUServer' => '0', 'rescheduleWaitTime' => '10',
-              'noAutoRebootWithLoggedOnUsers' => '0' }
+$defaults = { 'no_auto_update' => '0', 'au_options' => '4', 'scheduled_install_day' => '1',
+              'scheduled_install_time' => '1', 'use_wuserver' => '0', 'reschedule_wait_time' => '10',
+              'no_auto_reboot_with_logged_on_users' => '0' }
+
+$invalid_params = { 'no_auto_update' => '100', 'au_options' => '100', 'scheduled_install_day' => '100',
+                    'scheduled_install_time' => '100', 'use_wuserver' => '100', 'reschedule_wait_time' => '100',
+                    'no_auto_reboot_with_logged_on_users' => '100' }
 
 describe 'windows_autoupdate', :type => :class do
 
@@ -20,28 +16,55 @@ describe 'windows_autoupdate', :type => :class do
     { :operatingsystemrelease => '2008 R2' }
   end
 
-  let :hiera_data do
-    { :au_noAutoUpdate => '0', :au_aUOptions => '4', :au_scheduledInstallDay => '1', :au_scheduledInstallTime => '1',
-      :au_useWUServer => '0', :au_rescheduleWaitTime => '0', :au_noAutoRebootWithLoggedOnUsers => '0'
-    }
-  end
-
   context 'basic requirements' do
     let :params do
-      { :noAutoUpdate => '0', :aUOptions => '4', :scheduledInstallDay => '1',
-        :scheduledInstallTime => '1', :useWUServer => '0', :rescheduleWaitTime => '10',
-        :noAutoRebootWithLoggedOnUsers => '0' }
+      { :no_auto_update => '0', :au_options => '4', :scheduled_install_day => '1',
+        :scheduled_install_time => '1', :use_wuserver => '0', :reschedule_wait_time => '10',
+        :no_auto_reboot_with_logged_on_users => '0' }
     end
     it { should contain_registry_key($p_reg_key ) }
 
-    $defaults.keys.each do |value|
-      it { should contain_registry_value(value.titlecase).with(
+    it { should contain_registry_value('NoAutoUpdate').with(
         'ensure'  => 'present',
-        'path'    => "#{$p_reg_key}\\#{value.titlecase}",
+        'path'    => "#{$p_reg_key}\\NoAutoUpdate",
         'type'    => 'dword',
-        'data'    => $defaults[value]
-      )}
-    end
+        'data'    => 0
+    )}
+
+    it { should contain_registry_value('AUOptions').with(
+        'ensure'  => 'present',
+        'path'    => "#{$p_reg_key}\\AUOptions",
+        'type'    => 'dword',
+        'data'    => 4
+    )}
+
+    it { should contain_registry_value('ScheduledInstallDay').with(
+        'ensure'  => 'present',
+        'path'    => "#{$p_reg_key}\\ScheduledInstallDay",
+        'type'    => 'dword',
+        'data'    => 1
+    )}
+
+    it { should contain_registry_value('UseWUServer').with(
+        'ensure'  => 'present',
+        'path'    => "#{$p_reg_key}\\UseWUServer",
+        'type'    => 'dword',
+        'data'    => 0
+    )}
+
+    it { should contain_registry_value('RescheduleWaitTime').with(
+        'ensure'  => 'present',
+        'path'    => "#{$p_reg_key}\\RescheduleWaitTime",
+        'type'    => 'dword',
+        'data'    => 10
+    )}
+
+    it { should contain_registry_value('NoAutoRebootWithLoggedOnUsers').with(
+        'ensure'  => 'present',
+        'path'    => "#{$p_reg_key}\\NoAutoRebootWithLoggedOnUsers",
+        'type'    => 'dword',
+        'data'    => 0
+    )}
 
     it { should contain_service('wuauserv').with(
       'ensure' => 'running',
@@ -49,26 +72,42 @@ describe 'windows_autoupdate', :type => :class do
     )}
   end
 
-  $defaults.keys.each do |value|
-    context "passing custom param: #{value.titlecase}" do
-      let :params do
-        { value => '1' }
-      end
-      it { should contain_registry_value(value.titlecase).with(
-        'data' => '1'
-      )}
+  context "passing custom params" do
+    let :params do
+      { :no_auto_update => '1', :au_options => '1', :scheduled_install_day => '5',
+        :scheduled_install_time => '1', :use_wuserver => '1', :reschedule_wait_time => '1',
+        :no_auto_reboot_with_logged_on_users => '1' }
     end
+    it { should contain_registry_value('NoAutoUpdate').with('data' => '1')}
+    it { should contain_registry_value('AUOptions').with('data' => '1')}
+    it { should contain_registry_value('ScheduledInstallDay').with('data' => '5')}
+    it { should contain_registry_value('ScheduledInstallTime').with('data' => '1')}
+    it { should contain_registry_value('UseWUServer').with('data' => '1')}
+    it { should contain_registry_value('RescheduleWaitTime').with('data' => '1')}
+    it { should contain_registry_value('NoAutoRebootWithLoggedOnUsers').with('data' => '1')}
+  end
 
-    context "passing invalid param to: #{value.titlecase}" do
+  $invalid_params.keys.each do |key, value|
+    context "passing invalid param to #{key}" do
       let :params do
-        { value => '100' }
+        { :key => :value }
       end
-      it do
-        expect {
-         should contain_registry_value(value.titlecase)
-        }.to raise_error(Puppet::Error)
-      end
+      it { is_expected.to raise_error(Puppet::Error) }
     end
   end
 
+  context "Using deprecated params" do
+    let :params do
+      { :noAutoUpdate => '1', :aUOptions => '2', :scheduledInstallDay => '2',
+        :scheduledInstallTime => '2', :useWUServer => '1', :rescheduleWaitTime => '2',
+        :noAutoRebootWithLoggedOnUsers => '1' }
+    end
+    it { should contain_registry_value('NoAutoUpdate').with('data' => '1')}
+    it { should contain_registry_value('AUOptions').with('data' => '2')}
+    it { should contain_registry_value('ScheduledInstallDay').with('data' => '2')}
+    it { should contain_registry_value('ScheduledInstallTime').with('data' => '2')}
+    it { should contain_registry_value('UseWUServer').with('data' => '1')}
+    it { should contain_registry_value('RescheduleWaitTime').with('data' => '2')}
+    it { should contain_registry_value('NoAutoRebootWithLoggedOnUsers').with('data' => '1')}
+  end
 end


### PR DESCRIPTION
Mixed case parameters are discouraged by the Puppet Style Guide